### PR TITLE
Better record equality checking

### DIFF
--- a/lib/clouddns/version.rb
+++ b/lib/clouddns/version.rb
@@ -1,3 +1,3 @@
 module Clouddns
-  VERSION = "1.0.0.pre"
+  VERSION = "1.0.0"
 end

--- a/lib/clouddns/zone_migration.rb
+++ b/lib/clouddns/zone_migration.rb
@@ -72,7 +72,7 @@ module Clouddns
       # AWS replaces * with \052
       record.name == fog_record_name(fog_record) &&
         record.type == fog_record.type &&
-          (record.value.is_a?(Array) ? record.value.sort : record.value) == (fog_record.value.is_a?(Array) ? fog_record.value.sort : fog_record.value) &&
+          (record.value.respond_to?(:sort) ? record.value.sort : record.value) == (fog_record.value.respond_to?(:sort) ? fog_record.value.sort : fog_record.value) &&
         record.ttl.to_i == fog_record.ttl.to_i
     end
   end

--- a/lib/clouddns/zone_migration.rb
+++ b/lib/clouddns/zone_migration.rb
@@ -72,7 +72,7 @@ module Clouddns
       # AWS replaces * with \052
       record.name == fog_record_name(fog_record) &&
         record.type == fog_record.type &&
-          (record.value.is_a? Array ? record.value.sort : record.value) == (fog_record.value.is_a? Array ? fog_record.value.sort : fog_record.value) &&
+          (record.value.is_a?(Array) ? record.value.sort : record.value) == (fog_record.value.is_a?(Array) ? fog_record.value.sort : fog_record.value) &&
         record.ttl.to_i == fog_record.ttl.to_i
     end
   end

--- a/lib/clouddns/zone_migration.rb
+++ b/lib/clouddns/zone_migration.rb
@@ -72,7 +72,7 @@ module Clouddns
       # AWS replaces * with \052
       record.name == fog_record_name(fog_record) &&
         record.type == fog_record.type &&
-        record.value == fog_record.value &&
+        record.value.sort == fog_record.value.sort &&
         record.ttl.to_i == fog_record.ttl.to_i
     end
   end

--- a/lib/clouddns/zone_migration.rb
+++ b/lib/clouddns/zone_migration.rb
@@ -72,7 +72,7 @@ module Clouddns
       # AWS replaces * with \052
       record.name == fog_record_name(fog_record) &&
         record.type == fog_record.type &&
-        record.value.sort == fog_record.value.sort &&
+          (record.value.is_a? Array ? record.value.sort : record.value) == (fog_record.value.is_a? Array ? fog_record.value.sort : fog_record.value) &&
         record.ttl.to_i == fog_record.ttl.to_i
     end
   end


### PR DESCRIPTION
@jhawthorn I have another one for you

I needed to add support for equality checking arrays in different orders. AWS Route53 doesn't always return the same order for entries but I don't want the equality check to fail in those cases.
