### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.2
+  - jruby-19mode

--- a/clouddns.gemspec
+++ b/clouddns.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   # 0.9.0 changed Record#ip to Record#value
   gem.add_dependency('fog', '>= 0.9.0')
   gem.add_dependency('thor', '~> 0.18.1')
+  gem.add_development_dependency('rake')
 end


### PR DESCRIPTION
1. Add rake as a development dependency.
2. Add a .travis.yml file.

After this is merged @jhawthorn will need to go to http://travis-ci.org and enable CI for this repository
