### PR TITLE
[FIX] Fog requires you to call `all!` if you actually want it to fetch and return the full record list

### DIFF
--- a/lib/clouddns/zone_migration.rb
+++ b/lib/clouddns/zone_migration.rb
@@ -31,7 +31,7 @@ module Clouddns
     def changes
       return @changes if @changes
       @changes = []
-      fog_records = Hash[@fog_zone.records.map {|r| [[fog_record_name(r), r.type], r] } ]
+      fog_records = Hash[@fog_zone.records.all!.map {|r| [[fog_record_name(r), r.type], r] } ]
       @zone.records.each do |record|
         if (fog_record = fog_records.delete([record.name, record.type]))
           if records_equal?(record, fog_record)


### PR DESCRIPTION
Using the collection directly or via all only shows a limited set... for example 100 items for our setup using Route 53.
